### PR TITLE
Use PS7 if available for translation

### DIFF
--- a/Install.bat
+++ b/Install.bat
@@ -1,7 +1,8 @@
 @echo off
 
-IF EXIST "%ProgramFiles%\PowerShell\7\pwsh.exe" ("%ProgramFiles%\PowerShell\7\pwsh.exe" -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}")
-ELSE (%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}")
+IF EXIST "%ProgramFiles%\PowerShell\7\pwsh.exe" (
+         "%ProgramFiles%\PowerShell\7\pwsh.exe" -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; (iwr -useb 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | iex}"
+  ) ELSE (%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}")
 
 pause
 exit /b

--- a/Install.bat
+++ b/Install.bat
@@ -1,6 +1,7 @@
 @echo off
 
-%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}"
+IF EXIST "%ProgramFiles%\PowerShell\7\pwsh.exe" ("%ProgramFiles%\PowerShell\7\pwsh.exe" -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}")
+ELSE (%SYSTEMROOT%\System32\WindowsPowerShell\v1.0\powershell.exe -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12}"; "& {(Invoke-WebRequest -UseBasicParsing 'https://raw.githubusercontent.com/amd64fox/SpotX/main/Install.ps1').Content | Invoke-Expression}")
 
 pause
 exit /b


### PR DESCRIPTION
Check if [Powershell 7 ](https://github.com/PowerShell/PowerShell)available and use it for translation to work, else still old command (No translation).
Need update for other .bat installer.