### PR TITLE
path fix for cache_spotify.ps1

### DIFF
--- a/scripts/cache/cache_spotify.ps1
+++ b/scripts/cache/cache_spotify.ps1
@@ -9,16 +9,16 @@ by the customer more than the specified number of days will be deleted.
 
 #>
 
-$day = 7 # Number of days after which the cache is considered stale 
+$day = 7 # Number of days after which the cache is considered stale
 
 # Clear the \Data folder if it finds an outdated cache
-
 try {
-    If (!(Test-Path -Path $env:LOCALAPPDATA\Spotify\Data)) {
+    $SpotifyData = Join-Path -Path $env:LOCALAPPDATA -ChildPath "Spotify\Data"
+    If (!(Test-Path -Path $SpotifyData)) {
         "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Folder Local\Spotify\Data not found" | Out-File log.txt -append
         exit	
     }
-    $check = Get-ChildItem $env:LOCALAPPDATA\Spotify\Data -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day)
+    $check = Get-ChildItem $SpotifyData -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day)
     if ($check.Length -ge 1) {
 
         $count = $check
@@ -31,7 +31,7 @@ try {
             $mb = "{0:N2} Mb" -f (($check | Measure-Object Length -s).sum / 1Mb)
             "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Removed $mb obsolete cache" | Out-File log.txt -append
         }
-        Get-ChildItem $env:LOCALAPPDATA\Spotify\Data -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day) | Remove-Item
+        Get-ChildItem $SpotifyData -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day) | Remove-Item
     }
     if ($check.Length -lt 1) {
         "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Stale cache not found" | Out-File log.txt -append

--- a/scripts/cache/cache_spotify_ru.ps1
+++ b/scripts/cache/cache_spotify_ru.ps1
@@ -14,11 +14,12 @@ $day = 7 # Количество дней после которых кеш счи
 # Очищаем папку \Data если был найден устаревший кеш
 
 try {
-    If (!(Test-Path -Path $env:LOCALAPPDATA\Spotify\Data)) {
+    $SpotifyData = Join-Path -Path $env:LOCALAPPDATA -ChildPath "Spotify\Data"
+    If (!(Test-Path -Path $SpotifyData)) {
         "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Папка Local\Spotify\Data не найдена" | Out-File log.txt -append
         exit	
     }
-    $check = Get-ChildItem $env:LOCALAPPDATA\Spotify\Data -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day)
+    $check = Get-ChildItem $SpotifyData -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day)
     if ($check.Length -ge 1) {
 
         $count = $check
@@ -31,7 +32,7 @@ try {
             $mb = "{0:N2} Mb" -f (($check | Measure-Object Length -s).sum / 1Mb)
             "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Удалено $mb устаревшего кеша" | Out-File log.txt -append
         }
-        Get-ChildItem $env:LOCALAPPDATA\Spotify\Data -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day) | Remove-Item
+        Get-ChildItem $SpotifyData -File -Recurse | Where-Object lastaccesstime -lt (get-date).AddDays(-$day) | Remove-Item
     }
     if ($check.Length -lt 1) {
         "$(Get-Date -Format "dd/MM/yyyy HH:mm:ss") Устаревшего кеша не найдено" | Out-File log.txt -append


### PR DESCRIPTION
Properly join the path to prevent falsely flagging the path as nonexistent.