### PR TITLE
Switching the architecture from x86 to x64 in the default installation

### DIFF
--- a/run.ps1
+++ b/run.ps1
@@ -482,7 +482,22 @@ function downloadSp() {
 
     Import-Module BitsTransfer
         
-    $web_Url = "https://download.scdn.co/upgrade/client/win32-x86/spotify_installer-$onlineFull.exe"
+    $min_x86 = [Version]"1.2.52"
+
+    $archType = @{
+        "x86" = "win32-x86"
+        "x64" = "win32-x86_64"
+    }
+
+    $versionParts = $onlineFull -split '\.'
+    $short = [Version]"$($versionParts[0]).$($versionParts[1]).$($versionParts[2])"
+
+    if ($short -le $min_x86) {
+        $arch = $archType["x86"]
+    }
+    else { $arch = $archType["x64"] }
+
+    $web_Url = "https://download.scdn.co/$arch/client/win32-x86/spotify_installer-$onlineFull.exe"
     $local_Url = "$PWD\SpotifySetup.exe" 
     $web_name_file = "SpotifySetup.exe"
 

--- a/run.ps1
+++ b/run.ps1
@@ -497,7 +497,7 @@ function downloadSp() {
     }
     else { $arch = $archType["x64"] }
 
-    $web_Url = "https://download.scdn.co/$arch/client/win32-x86/spotify_installer-$onlineFull.exe"
+    $web_Url = "https://download.scdn.co/upgrade/client/$arch/spotify_installer-$onlineFull.exe"
     $local_Url = "$PWD\SpotifySetup.exe" 
     $web_name_file = "SpotifySetup.exe"
 

--- a/run.ps1
+++ b/run.ps1
@@ -482,7 +482,7 @@ function downloadSp() {
 
     Import-Module BitsTransfer
         
-    $min_x86 = [Version]"1.2.52"
+    $max_x86 = [Version]"1.2.53"
 
     $archType = @{
         "x86" = "win32-x86"
@@ -491,11 +491,7 @@ function downloadSp() {
 
     $versionParts = $onlineFull -split '\.'
     $short = [Version]"$($versionParts[0]).$($versionParts[1]).$($versionParts[2])"
-
-    if ($short -le $min_x86) {
-        $arch = $archType["x86"]
-    }
-    else { $arch = $archType["x64"] }
+    $arch = if ($short -le $max_x86) { $archType["x86"] } else { $archType["x64"] }
 
     $web_Url = "https://download.scdn.co/upgrade/client/$arch/spotify_installer-$onlineFull.exe"
     $local_Url = "$PWD\SpotifySetup.exe" 

--- a/run.ps1
+++ b/run.ps1
@@ -483,15 +483,9 @@ function downloadSp() {
     Import-Module BitsTransfer
         
     $max_x86 = [Version]"1.2.53"
-
-    $archType = @{
-        "x86" = "win32-x86"
-        "x64" = "win32-x86_64"
-    }
-
     $versionParts = $onlineFull -split '\.'
     $short = [Version]"$($versionParts[0]).$($versionParts[1]).$($versionParts[2])"
-    $arch = if ($short -le $max_x86) { $archType["x86"] } else { $archType["x64"] }
+    $arch = if ($short -le $max_x86) { "win32-x86" } else { "win32-x86_64" }
 
     $web_Url = "https://download.scdn.co/upgrade/client/$arch/spotify_installer-$onlineFull.exe"
     $local_Url = "$PWD\SpotifySetup.exe" 


### PR DESCRIPTION
Switching the architecture from x86 to x64 in the default installation for versions above 1.2.53

mentioned in the issue #650 