### PR TITLE
Fixed header formatting issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,17 @@
 </p>
 
 <p align="center">
-      <a href="https://t.me/spotify_windows_mod"><img src="https://spotx-official.github.io/images/shields/SpotX_Channel.svg"></a>
-        <a href="https://t.me/SpotxCommunity"><img src="https://spotx-official.github.io/images/shields/SpotX_Community.svg"></a>
-        <a href="https://github.com/SpotX-Official/SpotX-Bash"><img src="https://spotx-official.github.io/images/shields/SpotX_for_Mac&Linux.svg"></a>
-        <a href="https://telegra.ph/SpotX-FAQ-09-19"><img src="https://spotx-official.github.io/images/shields/faq.svg"></a>
-        </p>
-         <h2> <div align="center"><b> Patcher for Spotify Desktop Client on Windows </b></div> </h2>
+  <a href="https://t.me/spotify_windows_mod"><img src="https://spotx-official.github.io/images/shields/SpotX_Channel.svg"></a>
+  <a href="https://t.me/SpotxCommunity"><img src="https://spotx-official.github.io/images/shields/SpotX_Community.svg"></a>
+  <a href="https://github.com/SpotX-Official/SpotX-Bash"><img src="https://spotx-official.github.io/images/shields/SpotX_for_Mac&Linux.svg"></a>
+  <a href="https://telegra.ph/SpotX-FAQ-09-19"><img src="https://spotx-official.github.io/images/shields/faq.svg"></a>
+</p>
+
+<h2> 
+  <div align="center">
+    <b>Patcher for Spotify Desktop Client on Windows </b>
+  </div> 
+</h2>
 
 <p align="center"> •
   <a href="#requirements">Requirements</a> •


### PR DESCRIPTION
Fixed indentation problems in the README that caused formatting issues in the GitHub Pages site (https://spotx-official.github.io/SpotX/)

<img width="1608" height="572" alt="image" src="https://github.com/user-attachments/assets/5fc1ac2d-1ada-4f3b-b9e2-a511f9b7dfc4" />
