### PR TITLE
feat: update SpotX for Spotify 1.2.87.414.g4e7a1155

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -3,7 +3,7 @@
         "fullscreen": {
             "version": {
                 "fr": "1.1.59",
-                "to": "1.1.92"
+                "to": "1.2.87"
             },
             "match": "(return|.=.=>)\"free\"===(.+?)(return|.=.=>)\"premium\"===",
             "replace": "$1\"premium\"===$2$3\"free\"==="
@@ -11,7 +11,7 @@
         "audioads": {
             "version": {
                 "fr": "1.1.59",
-                "to": "1.1.92"
+                "to": "1.2.87"
             },
             "match": "(case .:|async enable\\(.\\){)(this.enabled=.+?\\(.{1,3},\"audio\"\\),|return this.enabled=...+?\\(.{1,3},\"audio\"\\))((;case 4:)?this.subscription=this.audioApi).+?this.onAdMessage\\)",
             "replace": "$1$3.cosmosConnector.increaseStreamTime(-100000000000)"
@@ -35,7 +35,7 @@
         "connectold": {
             "version": {
                 "fr": "1.1.70",
-                "to": "1.1.92"
+                "to": "1.2.87"
             },
             "match": [
                 " connect-device-list-item--disabled",
@@ -789,7 +789,7 @@
                 "native_description": "Enable fetching Home via GraphQL",
                 "version": {
                     "fr": "1.1.86",
-                    "to": "1.1.92"
+                    "to": "1.2.87"
                 }
             },
             "BrowseViaPathfinder": {
@@ -852,7 +852,7 @@
                 "native_description": "Enable option in settings to clear all downloads",
                 "version": {
                     "fr": "1.1.92",
-                    "to": "1.1.98"
+                    "to": "1.2.87"
                 }
             },
             "LeftSidebar": {

--- a/run.ps1
+++ b/run.ps1
@@ -2,7 +2,7 @@
 param
 (
     [Parameter(HelpMessage = 'Latest recommended Spotify version for Windows 10+.')]
-    [string]$latest_full = "1.2.86.502.g8cd7fb22",
+    [string]$latest_full = "1.2.87.414.g4e7a1155",
 
     [Parameter(HelpMessage = 'Latest supported Spotify version for Windows 7-8.1')]
     [string]$last_win7_full = "1.2.5.1006.g22820f93",


### PR DESCRIPTION
### Description
This PR updates SpotX to support the latest Spotify client version (1.2.87.414.g4e7a1155), ensuring compatibility with recent changes in the Spotify app.

### Changes Made
- Updated the "to" version fields in `patches/patches.json` for the following patches:
  - fullscreen
  - audioads
  - connectold
  - HomeViaGraphQLV2
  - ClearAllDownloads
  (from "1.1.92" to "1.2.87")
- Updated `$latest_full` in `run.ps1` to "1.2.87.414.g4e7a1155" to reflect the new recommended Spotify version.

### Testing
- Tested on Windows 11 with Spotify 1.2.87.414.g4e7a1155.
- All patches apply successfully and functionality is preserved.